### PR TITLE
add fastqc wrapper and test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cutadapt == 1.9.1
+fastqc == 0.11.5
 snakemake == 3.8.2
 pytest

--- a/test/test_cutadapt.py
+++ b/test/test_cutadapt.py
@@ -10,7 +10,7 @@ def test_cutadapt_simple(sample1_se_fq, tmpdir):
                     output:
                         fastq='sample1_R1.trim.fastq.gz'
                     params: extra='-a AAA'
-                    wrapper: {wrapper}
+                    wrapper: "file://wrapper"
                 '''
     input_data_func=symlink_in_tempdir(
         {
@@ -40,7 +40,7 @@ def test_cutadapt_simple_with_log(sample1_se_fq, tmpdir):
                         fastq='sample1_R1.trim.fastq.gz'
                     params: extra='-a AAA'
                     log: 'sample1.cutadapt.log'
-                    wrapper: {wrapper}
+                    wrapper: "file://wrapper"
                 '''
     input_data_func=symlink_in_tempdir(
         {
@@ -74,7 +74,7 @@ def test_cutadapt_pe(sample1_pe_fq, tmpdir):
                         R2='sample2_R1.trim.fastq.gz',
                     params: extra='-a AAA'
                     log: 'sample1.cutadapt.log'
-                    wrapper: {wrapper}
+                    wrapper: "file://wrapper"
                 '''
     input_data_func=symlink_in_tempdir(
         {

--- a/test/test_demo.py
+++ b/test/test_demo.py
@@ -1,9 +1,6 @@
 # This file demonstrates tests for the `demo` wrapper. It is heavily commented,
 # and is included as part of the test suite to ensure that it's correct.
 
-import os
-import gzip
-
 from utils import run
 # `run` does most of the work. It creates a tempdir, copys over input data,
 # Snakefile, and wrapper, runs the Snakefile, and runs a user-provided test

--- a/test/test_demo.py
+++ b/test/test_demo.py
@@ -52,14 +52,14 @@ def test_demo(sample1_se_fq, tmpdir):
     # automatically run through textwrap.dedent later so you don't have to
     # worry about indentation.
     #
-    # There is a `{wrapper}` placeholder which will automatically fill in the
-    # path to the wrapper within the temp dir so we don't have to manage any of
-    # that here.
+    # The wrapper will be copied to a subdirectory of the temp dir called,
+    # appropriately enough, "wrapper". So that's the name of the wrapper
+    # within the snakefile.
     snakefile = '''
     rule demo:
         input: 'a.fastq.gz'
         output: 'b.fastq.gz'
-        wrapper: {wrapper}
+        wrapper: "file://wrapper"
     '''
 
     # Map fixtures to input files
@@ -123,7 +123,7 @@ def test_demo_pe(sample1_pe_fq, tmpdir):
         output:
             R1='b1.fastq.gz',
             R2='b2.fastq.gz'
-        wrapper: {wrapper}
+        wrapper: "file://wrapper"
     '''
 
     # Map fixture to input files

--- a/test/test_fastqc.py
+++ b/test/test_fastqc.py
@@ -1,0 +1,23 @@
+import os
+import gzip
+from utils import run, dpath, rm, symlink_in_tempdir
+
+def test_fastqc(sample1_se_fq, tmpdir):
+    snakefile = '''
+    rule fastqc:
+        input:
+            fastq='sample1_R1.fastq.gz'
+        output:
+            html='results/sample1_R1.html',
+            zip='sample1_R1.zip'
+        wrapper: "file://wrapper"'''
+    input_data_func=symlink_in_tempdir(
+        {
+            sample1_se_fq: 'sample1_R1.fastq.gz'
+        }
+    )
+
+    def check():
+        assert '<html>' in open('results/sample1_R1.html').readline()
+
+    run(dpath('../wrappers/fastqc'), snakefile, check, input_data_func, tmpdir)

--- a/test/test_fastqc.py
+++ b/test/test_fastqc.py
@@ -1,5 +1,5 @@
 import os
-import gzip
+import zipfile
 from utils import run, dpath, rm, symlink_in_tempdir
 
 def test_fastqc(sample1_se_fq, tmpdir):
@@ -19,5 +19,27 @@ def test_fastqc(sample1_se_fq, tmpdir):
 
     def check():
         assert '<html>' in open('results/sample1_R1.html').readline()
+        assert zipfile.ZipFile('sample1_R1.zip').namelist() == [
+            'sample1_R1_fastqc/',
+            'sample1_R1_fastqc/Icons/',
+            'sample1_R1_fastqc/Images/',
+            'sample1_R1_fastqc/Icons/fastqc_icon.png',
+            'sample1_R1_fastqc/Icons/warning.png',
+            'sample1_R1_fastqc/Icons/error.png',
+            'sample1_R1_fastqc/Icons/tick.png',
+            'sample1_R1_fastqc/summary.txt',
+            'sample1_R1_fastqc/Images/per_base_quality.png',
+            'sample1_R1_fastqc/Images/per_tile_quality.png',
+            'sample1_R1_fastqc/Images/per_sequence_quality.png',
+            'sample1_R1_fastqc/Images/per_base_sequence_content.png',
+            'sample1_R1_fastqc/Images/per_sequence_gc_content.png',
+            'sample1_R1_fastqc/Images/per_base_n_content.png',
+            'sample1_R1_fastqc/Images/sequence_length_distribution.png',
+            'sample1_R1_fastqc/Images/duplication_levels.png',
+            'sample1_R1_fastqc/Images/adapter_content.png',
+            'sample1_R1_fastqc/fastqc_report.html',
+            'sample1_R1_fastqc/fastqc_data.txt',
+            'sample1_R1_fastqc/fastqc.fo'
+        ]
 
     run(dpath('../wrappers/fastqc'), snakefile, check, input_data_func, tmpdir)

--- a/test/utils.py
+++ b/test/utils.py
@@ -76,7 +76,7 @@ def run(path, snakefile, check, input_data_func=None, tmpdir=None, **params):
 
         # write the snakefile, filling in the "wrapper" placeholder
         with open(os.path.join(tmpdir, 'Snakefile'), 'w') as fout:
-            fout.write(dedent(snakefile.format(wrapper='"file://wrapper"')))
+            fout.write(dedent(snakefile))
 
         # Create the input data
         input_data_func(tmpdir)

--- a/wrappers/fastqc/README.md
+++ b/wrappers/fastqc/README.md
@@ -1,0 +1,32 @@
+# Wrapper for FastQC
+
+[FastQC](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/) performs
+quality control for high-throughput sequencing data.
+
+## Input
+FASTQ, SAM, or BAM file. FastQC will auto-detect, but you can also use
+`--format` and one of bam, sam, bam_mapped, sam_mapped or fastq in the
+params.extra field (see example).
+
+## Output
+- html: an html file containing the report for the sample
+- zip: a zip file containing the images and text file of results
+
+## Threads
+Supports threads, passed in as the `--threads` arg
+
+## Params
+Additional parameters can be passed to FastQC verbatim by supplying a string in params.extra.
+
+# Example
+
+```
+rule fastqc:
+    input: 'samples/{sample}.fastq'
+    output:
+        html='samples/{sample}.fastqc.html',
+        zip='samples/{sample}.fastqc.zip'
+    params: extra="--contaminants adapters.tsv --format fastq"
+    wrapper:
+        "file://path/to/fastqc"
+```

--- a/wrappers/fastqc/environment.yaml
+++ b/wrappers/fastqc/environment.yaml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - fastqc

--- a/wrappers/fastqc/wrapper.py
+++ b/wrappers/fastqc/wrapper.py
@@ -1,0 +1,47 @@
+__author__ = "Ryan Dale"
+__copyright__ = "Copyright 2016, Ryan Dale"
+__email__ = "dalerr@niddk.nih.gov"
+__license__ = "MIT"
+
+import os
+from snakemake.shell import shell
+from snakemake.utils import makedirs
+
+# fastqc creates a zip file and an html file but the filename is hard-coded by
+# replacing fastq|fastq.gz|fq|fq.gz|bam with _fastqc.zip|_fastqc.html in the
+# input file's basename.
+#
+# So we identify that file and move it to the expected output after fastqc is
+# done.
+
+outfile = os.path.basename(snakemake.input[0])
+outdir = os.path.dirname(snakemake.output.html)
+if outdir == '':
+    outdir = '.'
+
+strip = ['.fastq', '.fq', '.gz', '.bam']
+for s in strip:
+    outfile = outfile.replace(s, '')
+out_zip = os.path.join(outdir, outfile + '_fastqc.zip')
+out_html = os.path.join(outdir, outfile + '_fastqc.html')
+try:
+    extra = snakemake.params.extra
+except AttributeError:
+    extra = ""
+
+log = snakemake.log_fmt_shell()
+
+shell(
+    'fastqc '
+    '--threads {snakemake.threads} '
+    '--noextract '
+    '--quiet '
+    '--outdir {outdir} '
+    '{extra} '
+    '{snakemake.input} '
+    '{log} '
+)
+if out_zip != snakemake.output.zip:
+    shell('mv {out_zip} {snakemake.output.zip}')
+if out_html != snakemake.output.html:
+    shell('mv {out_html} {snakemake.output.html}')


### PR DESCRIPTION
Minor simplification here on writing test snakefiles. Don't need to use the confusing "{wrapper}" placeholder, just use "file://wrapper" as the wrapper path.

This also shows the kind of thing I'm testing -- very coarse presence/absence of files in the correct format, rather than byte-for-byte correctness.