### PR TITLE
Use conda

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -30,7 +30,7 @@ def md5sum(filename):
     return hashlib.md5(data).hexdigest()
 
 
-def run(path, snakefile, check=None, input_data_func=None, tmpdir=None, use_conda=True, **params):
+def run(path, snakefile, check=None, input_data_func=None, tmpdir=None, use_conda=False, **params):
     """
     Parameters
     ----------

--- a/test/utils.py
+++ b/test/utils.py
@@ -30,7 +30,7 @@ def md5sum(filename):
     return hashlib.md5(data).hexdigest()
 
 
-def run(path, snakefile, check=None, input_data_func=None, tmpdir=None, **params):
+def run(path, snakefile, check=None, input_data_func=None, tmpdir=None, use_conda=True, **params):
     """
     Parameters
     ----------
@@ -85,7 +85,7 @@ def run(path, snakefile, check=None, input_data_func=None, tmpdir=None, **params
         input_data_func(tmpdir)
 
         success = snakemake(os.path.join(tmpdir, 'Snakefile'), workdir=tmpdir, stats='stats.txt',
-                            snakemakepath=SCRIPTPATH, config={}, **params)
+                            snakemakepath=SCRIPTPATH, config={}, use_conda=use_conda, **params)
         assert success, 'expected successful execution'
 
         # Change to the tmpdir and run the test function

--- a/wrappers/bowtie2/align/environment.yaml
+++ b/wrappers/bowtie2/align/environment.yaml
@@ -3,3 +3,5 @@ channels:
 dependencies:
   - bowtie2
   - samtools
+  - pip:
+      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/bowtie2/build/environment.yaml
+++ b/wrappers/bowtie2/build/environment.yaml
@@ -3,4 +3,4 @@ channels:
 dependencies:
   - bowtie2
   - pip:
-      - git+git://github.com/lcdb/lcdblib
+      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/cutadapt/environment.yaml
+++ b/wrappers/cutadapt/environment.yaml
@@ -2,3 +2,5 @@ channels:
   - bioconda
 dependencies:
   - cutadapt >=1.9.1
+  - pip:
+      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/demo/environment.yaml
+++ b/wrappers/demo/environment.yaml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+dependencies:
+  - pip:
+      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/fastqc/environment.yaml
+++ b/wrappers/fastqc/environment.yaml
@@ -2,3 +2,5 @@ channels:
   - bioconda
 dependencies:
   - fastqc
+  - pip:
+      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/featurecounts/environment.yaml
+++ b/wrappers/featurecounts/environment.yaml
@@ -2,3 +2,5 @@ channels:
   - bioconda
 dependencies:
   - subread
+  - pip:
+      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/hisat2/align/environment.yaml
+++ b/wrappers/hisat2/align/environment.yaml
@@ -3,3 +3,5 @@ channels:
 dependencies:
   - hisat2
   - samtools
+  - pip:
+      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/hisat2/build/environment.yaml
+++ b/wrappers/hisat2/build/environment.yaml
@@ -3,4 +3,4 @@ channels:
 dependencies:
   - hisat2
   - pip:
-      - git+git://github.com/lcdb/lcdblib
+      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/multiqc/environment.yaml
+++ b/wrappers/multiqc/environment.yaml
@@ -2,3 +2,5 @@ channels:
   - bioconda
 dependencies:
   - multiqc
+  - pip:
+      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/picard/collectrnaseqmetrics/environment.yaml
+++ b/wrappers/picard/collectrnaseqmetrics/environment.yaml
@@ -4,3 +4,5 @@ channels:
 dependencies:
   - picard
   - r
+  - pip:
+      - git+https://github.com/lcdb/lcdblib.git@master


### PR DESCRIPTION
Not ready for merge!

I exposed the `--use-conda` option to the run function. I started to set it as `True` by default, but tests were running extremely slowly. 

Unfortunately this PR requires a patch to `snakemake`. The problem is when using `--use-conda` the wrappers need absolute paths specified, this patch makes it so relative paths work too.

```patch
diff --git a/snakemake/conda.py b/snakemake/conda.py
index 7a37f6c..d6c07b4 100644
--- a/snakemake/conda.py
+++ b/snakemake/conda.py
@@ -31,7 +31,11 @@ def create_env(job):
         with open(env_file, 'rb') as f:
             md5hash.update(f.read())
     else:
-        content = urlopen(env_file).read()
+        if env_file.startswith('file://'):
+            with open(env_file.lstrip('file://'), 'rb') as handle:
+                    content = handle.read()
+        else:
+            content = urlopen(env_file).read()
         md5hash.update(content)
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             tmp.write(content)
```

I submitted an issue to snakemake and they are going to work on it at the hackathon next week. 