### PR TITLE
remove pip install lcdblib

### DIFF
--- a/wrappers/fastqc/environment.yaml
+++ b/wrappers/fastqc/environment.yaml
@@ -2,5 +2,3 @@ channels:
   - bioconda
 dependencies:
   - fastqc
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/featurecounts/environment.yaml
+++ b/wrappers/featurecounts/environment.yaml
@@ -2,5 +2,3 @@ channels:
   - bioconda
 dependencies:
   - subread
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master


### PR DESCRIPTION
Some leftover lcdblib in environment.yaml files that aren't needed by the wrapper