### PR TITLE
Hotfix more env fix

### DIFF
--- a/wrappers/bowtie2/align/environment.yaml
+++ b/wrappers/bowtie2/align/environment.yaml
@@ -1,7 +1,22 @@
 channels:
   - bioconda
+  - defaults
+  - conda-forge
 dependencies:
   - bowtie2
   - samtools
+# for lcdblib
+  - pytest >=2.9.2
+  - snakemake >=3.8
+  - pandas >=0.18.1
+  - seaborn >=0.7.0
+  - numpy >=1.11.1
+  - matplotlib >=1.5.1
+  - ipython >=5.1.0
+  - jsonschema >=2.5.1
+  - pyyaml >=3.11
+  - pybedtools >=0.7.8
+  - pysam >=0.9.1.4
+  - biopython >=1.6.8
   - pip:
       - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/cutadapt/environment.yaml
+++ b/wrappers/cutadapt/environment.yaml
@@ -2,5 +2,3 @@ channels:
   - bioconda
 dependencies:
   - cutadapt >=1.9.1
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/multiqc/environment.yaml
+++ b/wrappers/multiqc/environment.yaml
@@ -2,5 +2,3 @@ channels:
   - bioconda
 dependencies:
   - multiqc
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/picard/collectrnaseqmetrics/environment.yaml
+++ b/wrappers/picard/collectrnaseqmetrics/environment.yaml
@@ -4,5 +4,3 @@ channels:
 dependencies:
   - picard
   - r
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/rseqc/bam_stat/environment.yaml
+++ b/wrappers/rseqc/bam_stat/environment.yaml
@@ -1,5 +1,5 @@
 channels:
-    - bioconda
-    - r
+  - bioconda
+  - r
 dependencies:
-    - rseqc >=2.6.2
+  - rseqc >=2.6.2

--- a/wrappers/rseqc/geneBody_coverage/environment.yaml
+++ b/wrappers/rseqc/geneBody_coverage/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - bioconda
   - r
+  - defaults
   - conda-forge
 dependencies:
   - rseqc >=2.6.2

--- a/wrappers/rseqc/geneBody_coverage/environment.yaml
+++ b/wrappers/rseqc/geneBody_coverage/environment.yaml
@@ -1,7 +1,8 @@
 channels:
-    - bioconda
-    - r
+  - bioconda
+  - r
+  - conda-forge
 dependencies:
-    - rseqc >=2.6.2
-    - r-essentials
-    - icu >=56.1
+  - rseqc >=2.6.2
+  - r-essentials
+  - icu >=56.1

--- a/wrappers/rseqc/infer_experiment/environment.yaml
+++ b/wrappers/rseqc/infer_experiment/environment.yaml
@@ -1,5 +1,5 @@
 channels:
-    - bioconda
-    - r
+  - bioconda
+  - r
 dependencies:
-    - rseqc >=2.6.2
+  - rseqc >=2.6.2

--- a/wrappers/rseqc/tin/environment.yaml
+++ b/wrappers/rseqc/tin/environment.yaml
@@ -1,5 +1,5 @@
 channels:
-    - bioconda
-    - r
+  - bioconda
+  - r
 dependencies:
-    - rseqc >=2.6.2
+  - rseqc >=2.6.2


### PR DESCRIPTION
rseqc geneBody_coverage was not working when I did not have my channels in condarc. Turned out to be conda-forge installing some other stuff that should be from the defaults.