### PR TITLE
Adds lcdblib requirements to environment.

### DIFF
--- a/test/test_bowtie2.py
+++ b/test/test_bowtie2.py
@@ -39,7 +39,7 @@ def _dict_of_bowtie2_indexes(bowtie2_indexes, prefix):
     return d
 
 
-def test_bowtie2_align_se(bowtie2_indexes, sample1_se_fq, tmpdir):
+def test_bt2_align_se(bowtie2_indexes, sample1_se_fq, tmpdir):
     d = _dict_of_bowtie2_indexes(bowtie2_indexes, '2L')
     indexes = list(d.values())
     snakefile = '''
@@ -62,7 +62,7 @@ def test_bowtie2_align_se(bowtie2_indexes, sample1_se_fq, tmpdir):
         assert int(list(shell('samtools view -c -f 0x04 sample1.bam', iterable=True))[0]) > 0
         assert int(list(shell('samtools view -c -F 0x04 sample1.bam', iterable=True))[0]) > 0
 
-    run(dpath('../wrappers/bowtie2/align'), snakefile, check, input_data_func, tmpdir)
+    run(dpath('../wrappers/bowtie2/align'), snakefile, check, input_data_func, tmpdir, use_conda=True)
 
 
 def test_bowtie2_align_se_rm_unmapped(bowtie2_indexes, sample1_se_fq, tmpdir):

--- a/test/test_hisat2.py
+++ b/test/test_hisat2.py
@@ -62,7 +62,7 @@ def test_hisat2_align_se(hisat2_indexes, sample1_se_fq, tmpdir):
         assert int(list(shell('samtools view -c -f 0x04 sample1.bam', iterable=True))[0]) > 0
         assert int(list(shell('samtools view -c -F 0x04 sample1.bam', iterable=True))[0]) > 0
 
-    run(dpath('../wrappers/hisat2/align'), snakefile, check, input_data_func, tmpdir)
+    run(dpath('../wrappers/hisat2/align'), snakefile, check, input_data_func, tmpdir, use_conda=True)
 
 
 def test_hisat2_align_se_SRA(hisat2_indexes, tmpdir):

--- a/wrappers/bowtie2/align/environment.yaml
+++ b/wrappers/bowtie2/align/environment.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - bowtie2
   - samtools
-# for lcdblib
+# Needed for lcdblib
   - pytest >=2.9.2
   - snakemake >=3.8
   - pandas >=0.18.1

--- a/wrappers/bowtie2/build/environment.yaml
+++ b/wrappers/bowtie2/build/environment.yaml
@@ -2,5 +2,18 @@ channels:
   - bioconda
 dependencies:
   - bowtie2
+# Needed for lcdblib
+  - pytest >=2.9.2
+  - snakemake >=3.8
+  - pandas >=0.18.1
+  - seaborn >=0.7.0
+  - numpy >=1.11.1
+  - matplotlib >=1.5.1
+  - ipython >=5.1.0
+  - jsonschema >=2.5.1
+  - pyyaml >=3.11
+  - pybedtools >=0.7.8
+  - pysam >=0.9.1.4
+  - biopython >=1.6.8
   - pip:
       - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/demo/environment.yaml
+++ b/wrappers/demo/environment.yaml
@@ -1,5 +1,18 @@
 channels:
   - bioconda
 dependencies:
+# Needed for lcdblib
+  - pytest >=2.9.2
+  - snakemake >=3.8
+  - pandas >=0.18.1
+  - seaborn >=0.7.0
+  - numpy >=1.11.1
+  - matplotlib >=1.5.1
+  - ipython >=5.1.0
+  - jsonschema >=2.5.1
+  - pyyaml >=3.11
+  - pybedtools >=0.7.8
+  - pysam >=0.9.1.4
+  - biopython >=1.6.8
   - pip:
       - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/hisat2/align/environment.yaml
+++ b/wrappers/hisat2/align/environment.yaml
@@ -1,7 +1,21 @@
 channels:
   - bioconda
+  - defaults
 dependencies:
   - hisat2
   - samtools
+# Needed for lcdblib
+  - pytest >=2.9.2
+  - snakemake >=3.8
+  - pandas >=0.18.1
+  - seaborn >=0.7.0
+  - numpy >=1.11.1
+  - matplotlib >=1.5.1
+  - ipython >=5.1.0
+  - jsonschema >=2.5.1
+  - pyyaml >=3.11
+  - pybedtools >=0.7.8
+  - pysam >=0.9.1.4
+  - biopython >=1.6.8
   - pip:
       - git+https://github.com/lcdb/lcdblib.git@master

--- a/wrappers/hisat2/build/environment.yaml
+++ b/wrappers/hisat2/build/environment.yaml
@@ -2,5 +2,18 @@ channels:
   - bioconda
 dependencies:
   - hisat2
+# Needed for lcdblib
+  - pytest >=2.9.2
+  - snakemake >=3.8
+  - pandas >=0.18.1
+  - seaborn >=0.7.0
+  - numpy >=1.11.1
+  - matplotlib >=1.5.1
+  - ipython >=5.1.0
+  - jsonschema >=2.5.1
+  - pyyaml >=3.11
+  - pybedtools >=0.7.8
+  - pysam >=0.9.1.4
+  - biopython >=1.6.8
   - pip:
       - git+https://github.com/lcdb/lcdblib.git@master


### PR DESCRIPTION
As we start to use these wrappers I think it is important the use-conda works.
To get around some of the slowness with building lcdblib I have gone a head and
added the requirements to all of the environment.yaml files that needed them. We
still cannot make use_conda=True default because of the 80 chr name limit would
require renaming all of the test functions.but I have a few tests (bowtie2 aln
se and hisat2 aln se) working with use_conda. Once lcdblib is at a stable
release in conda we can delete the requirements.