### PR TITLE
Kallisto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 install: bash travis-setup.sh
 before_script:
-  - export PATH=/anaconda/bin:$PATH
+  - export PATH=$HOME/anaconda/bin:$PATH
   - export JAVA_HOME=
 script: py.test test -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: required
 install: bash travis-setup.sh
 before_script:
   - export PATH=/anaconda/bin:$PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ bowtie2 >=2.2.8
 multiqc >=0.8
 gffutils >=0.8.7.1
 pybedtools >=0.7.8
+kallisto >=0.43.0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -36,6 +36,34 @@ def _download_file(fn, d):
 
 
 @pytest.fixture(scope='session')
+def transcriptome(tmpdir_factory):
+    d = tmpdir_for_func(tmpdir_factory)
+    fn = 'seq/transcriptome.fa'
+    return _download_file(fn, d)
+
+
+@pytest.fixture(scope='session')
+def kallisto_index(tmpdir_factory, transcriptome):
+    d = tmpdir_for_func(tmpdir_factory)
+    snakefile = '''
+    rule kallisto:
+        input: fasta='transcriptome.fa'
+        output: index='transcriptome.idx'
+        wrapper: 'file://wrapper'
+    '''
+    input_data_func = symlink_in_tempdir(
+        {
+            transcriptome: 'transcriptome.fa',
+        }
+    )
+
+    run(
+        dpath('../wrappers/kallisto/index'),
+        snakefile, None, input_data_func, d)
+    return os.path.join(d, 'transcriptome.idx')
+
+
+@pytest.fixture(scope='session')
 def sample1_se_fq(tmpdir_factory):
     d = tmpdir_for_func(tmpdir_factory)
     fn = 'samples/sample1/sample1_R1.fastq.gz'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -144,12 +144,9 @@ def hisat2_indexes(dm6_fa, tmpdir_factory):
         }
     )
 
-    def check():
-        pass
-
     run(
         dpath('../wrappers/hisat2/build'),
-        snakefile, check, input_data_func, d)
+        snakefile, None, input_data_func, d)
     return aligners.hisat2_index_from_prefix(os.path.join(d, '2L'))
 
 
@@ -168,12 +165,9 @@ def bowtie2_indexes(dm6_fa, tmpdir_factory):
         }
     )
 
-    def check():
-        pass
-
     run(
         dpath('../wrappers/bowtie2/build'),
-        snakefile, check, input_data_func, d)
+        snakefile, None, input_data_func, d)
     return aligners.bowtie2_index_from_prefix(os.path.join(d, '2L'))
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -67,6 +67,7 @@ def sample1_se_bam(tmpdir_factory):
     fn = 'samples/sample1/sample1.single.bam'
     return _download_file(fn, d)
 
+
 @pytest.fixture(scope='session')
 def sample1_se_sort_bam(sample1_se_bam):
     sample1_se_sort_bam = sample1_se_bam.replace('.bam', '.sort.bam')
@@ -78,6 +79,7 @@ def sample1_se_sort_bam(sample1_se_bam):
             )
     return sample1_se_sort_bam
 
+
 @pytest.fixture(scope='session')
 def sample1_se_sort_bam_bai(sample1_se_sort_bam):
     shell(
@@ -86,11 +88,13 @@ def sample1_se_sort_bam_bai(sample1_se_sort_bam):
             )
     return sample1_se_sort_bam + '.bai'
 
+
 @pytest.fixture(scope='session')
 def sample1_pe_bam(tmpdir_factory):
     d = tmpdir_for_func(tmpdir_factory)
     fn = 'samples/sample1/sample1.paired.bam'
     return _download_file(fn, d)
+
 
 @pytest.fixture(scope='session')
 def sample1_pe_hisat2_bam(tmpdir_factory):
@@ -111,9 +115,13 @@ def hisat2_indexes(dm6_fa, tmpdir_factory):
             dm6_fa: '2L.fa'
         }
     )
+
     def check():
         pass
-    run(dpath('../wrappers/hisat2/build'), snakefile, check, input_data_func, d)
+
+    run(
+        dpath('../wrappers/hisat2/build'),
+        snakefile, check, input_data_func, d)
     return aligners.hisat2_index_from_prefix(os.path.join(d, '2L'))
 
 
@@ -131,9 +139,13 @@ def bowtie2_indexes(dm6_fa, tmpdir_factory):
             dm6_fa: '2L.fa'
         }
     )
+
     def check():
         pass
-    run(dpath('../wrappers/bowtie2/build'), snakefile, check, input_data_func, d)
+
+    run(
+        dpath('../wrappers/bowtie2/build'),
+        snakefile, check, input_data_func, d)
     return aligners.bowtie2_index_from_prefix(os.path.join(d, '2L'))
 
 
@@ -154,12 +166,13 @@ def annotation_refflat(tmpdir_factory):
 @pytest.fixture(scope='session')
 def annotation_db(annotation):
     import gffutils
-    gffutils.create_db(data=annotation, dbfn=annotation + '.db',
-            merge_strategy='merge',
-            id_spec={'transcript': ['transcript_id', 'transcript_symbol'],
-                     'gene': ['gene_id', 'gene_symbol']},
-            gtf_transcript_key='transcript_id',
-            gtf_gene_key='gene_id')
+    gffutils.create_db(
+        data=annotation, dbfn=annotation + '.db',
+        merge_strategy='merge',
+        id_spec={'transcript': ['transcript_id', 'transcript_symbol'],
+                 'gene': ['gene_id', 'gene_symbol']},
+        gtf_transcript_key='transcript_id',
+        gtf_gene_key='gene_id')
 
     return annotation + '.db'
 
@@ -188,7 +201,7 @@ def fastqc(sample1_se_fq, tmpdir_factory):
             html='sample1_R1_fastqc.html',
             zip='sample1_R1_fastqc.zip'
         wrapper: "file://wrapper"'''
-    input_data_func=symlink_in_tempdir(
+    input_data_func = symlink_in_tempdir(
         {
             sample1_se_fq: 'sample1_R1.fastq.gz'
         }

--- a/test/test_kallisto.py
+++ b/test/test_kallisto.py
@@ -1,0 +1,65 @@
+import pytest
+import json
+import pysam
+from snakemake.shell import shell
+from lcdblib.snakemake import aligners
+from utils import run, dpath, rm, symlink_in_tempdir
+
+
+def test_kallisto_index(transcriptome, tmpdir):
+    snakefile = '''
+    rule kallisto:
+        input: fasta='transcriptome.fa'
+        output: index='out/transcriptome.idx'
+        log: 'log'
+        wrapper: 'file://wrapper'
+    '''
+    input_data_func = symlink_in_tempdir(
+        {
+            transcriptome: 'transcriptome.fa',
+        }
+    )
+
+    def check():
+        log = open('log').read()
+        assert '[build] target deBruijn graph'
+
+    run(
+        dpath('../wrappers/kallisto/index'),
+        snakefile, check, input_data_func, tmpdir)
+
+
+def test_kallisto_quant(tmpdir, sample1_se_fq, kallisto_index):
+    snakefile = '''
+    rule kallisto_quant:
+        input:
+             fastq='sample1.fq.gz',
+             index='out/transcriptome.idx'
+
+        params: extra='--single --fragment-length=200 --sd=20'
+        output:
+            h5='quant/abundance.h5',
+            tsv='quant/abundance.tsv',
+            json='quant/run_info.json',
+        wrapper: 'file://wrapper'
+    '''
+    input_data_func = symlink_in_tempdir(
+        {
+            sample1_se_fq: 'sample1.fq.gz',
+            kallisto_index: 'out/transcriptome.idx',
+        }
+    )
+
+    def check():
+        assert sum(1 for _ in open('quant/abundance.tsv')) == 35
+        assert open('quant/abundance.tsv').readline() == (
+                'target_id\tlength\teff_length\test_counts\ttpm\n')
+        keys = ['call', 'index_version', 'n_bootstraps', 'n_processed', 'n_targets', 'start_time']
+        d = json.load(open('quant/run_info.json'))
+        for k in keys:
+            assert k in d
+
+
+    run(
+        dpath('../wrappers/kallisto/quant'),
+        snakefile, check, input_data_func, tmpdir)

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -3,15 +3,8 @@ set -euo pipefail
 set -x
 
 # Sets up travis-ci environment for testing bioconda-utils.
-
-if [[ $TRAVIS_OS_NAME = "linux" ]]
-then
-    tag=Linux
-else
-    tag=MacOSX
-fi
-curl -O https://repo.continuum.io/miniconda/Miniconda3-latest-${tag}-x86_64.sh
-sudo bash Miniconda3-latest-${tag}-x86_64.sh -b -p /anaconda
+curl -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+sudo bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
 sudo chown -R $USER /anaconda
 export PATH=/anaconda/bin:$PATH
 

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -4,9 +4,8 @@ set -x
 
 # Sets up travis-ci environment for testing bioconda-utils.
 curl -O https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-sudo bash Miniconda3-latest-Linux-x86_64.sh -b -p /anaconda
-sudo chown -R $USER /anaconda
-export PATH=/anaconda/bin:$PATH
+bash Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/anaconda
+export PATH=$HOME/anaconda/bin:$PATH
 
 # Add channels in the specified order.
 conda config --add channels conda-forge

--- a/wrappers/kallisto/README.md
+++ b/wrappers/kallisto/README.md
@@ -1,0 +1,4 @@
+Kallisto quantifies reads in transcripts.
+
+It has two main programs: `index` and `quant`; you can read more about them in
+their respective READMEs.

--- a/wrappers/kallisto/index/README.md
+++ b/wrappers/kallisto/index/README.md
@@ -1,0 +1,42 @@
+# Wrapper for Kallisto index
+
+Builds an index for Kallisto.
+
+## Examples
+
+Minimal usage:
+
+```python
+rule kallisto_index:
+    input: fasta='transcriptome.fa'
+    output: index='transcriptome.idx'
+    wrapper:
+        'file://path/to/wrapper'
+```
+
+Use a log and specify where the `stats` file should go:
+
+```python
+rule kallisto_index:
+    input: fasta='transcriptome.fa'
+    output:
+        index='transcriptome.idx',
+        stats='transcriptome.idx.stats'
+    log: 'transcriptome.idx.log'
+    wrapper:
+        'file://path/to/wrapper'
+```
+
+## Input
+
+* `fasta`: transcriptome FASTA file
+
+## Output
+
+* `index`: Filename of kallisto index file.
+
+## Threads
+Does not use threads
+
+## Params
+`params.extra` are passed verbatim.

--- a/wrappers/kallisto/index/wrapper.py
+++ b/wrappers/kallisto/index/wrapper.py
@@ -1,0 +1,12 @@
+from snakemake.shell import shell
+import json
+
+extra = snakemake.params.get('extra', '')
+log = snakemake.log_fmt_shell()
+
+shell(
+    'kallisto index {snakemake.input.fasta} '
+    '--index {snakemake.output.index} '
+    '{extra} '
+    '{log} '
+)

--- a/wrappers/kallisto/quant/README.md
+++ b/wrappers/kallisto/quant/README.md
@@ -1,0 +1,85 @@
+# Wrapper for `kallisto quant`
+
+
+[Kallisto home](https://pachterlab.github.io/kallisto/)
+
+[Kallisto manual](https://pachterlab.github.io/kallisto/manual)
+
+## Examples
+
+Single-end reads example, with recommended `extra` args:
+
+```python
+rule kallisto_quant:
+    input:
+        fastq="{sample}.fastq.gz",
+        index="references/dm6/kallisto.idx"
+    output:
+        h5="quant/kallisto/{sample}/abundance.h5",
+        tsv="quant/kallisto/{sample}/abundance.tsv",
+        json="quant/kallisto/{sample}/run_info.json"
+    log: "quant/kallisto/{sample}/kallisto.log"
+    params: extra="--fragment-length=200 --sd=20 --single"
+    wrapper:
+        "/path/to/wrapper/location"
+```
+
+Paired-end, simplified example:
+
+```python
+rule kallisto_quant:
+    input:
+        fastq=["{sample}_R1.fastq.gz", "{sample}_R2.fastq.gz"]
+        index="references/dm6/kallisto.idx"
+    output:
+        h5="quant/kallisto/{sample}/abundance.h5",
+        tsv="quant/kallisto/{sample}/abundance.tsv",
+        json="quant/kallisto/{sample}/run_info.json"
+```
+
+## Input
+
+* `index`: kallisto index file
+
+* `fastq`: either a pair of PE fastqs or a single fastq. If single, see note in *Params* section.
+
+## Output
+
+- `h5`: HDF5 quantification file
+- `tsv`: TSV quantification file
+- `json`: JSON metadata
+
+`kallisto quant` outputs files hard-coded as:
+
+```
+outdir/
+├── abundance.h5
+├── abundance.tsv
+└── run_info.json
+```
+
+Since the downstream `sleuth` tool expects these hard-coded names, we do not
+move them. It is recommended that you use the sample name in the directory path
+to separate them (see examples).
+
+The `--output-dir` argument to `kallisto quant` is determined from the output
+files, and the wrapper checks to make sure they are all in the same directory.
+
+## Threads
+
+Threads are passed as the `--threads` argument to `kallisto quant`.
+
+## Params
+
+* `extra`: passed verbatim to `kallisto quant`
+
+*NOTE:* if you are using single-end reads, then kallisto will complain if you
+don't set the `--fragment-length` and `--sd` params. Add them to extra. Based
+on [this
+comment](https://groups.google.com/forum/#!searchin/kallisto-sleuth-users/sd/kallisto-sleuth-users/VPJfzL502bw/e2JDq7ezBgAJ)
+from the author, `--fragment-length=200 --sd=20` should be a good starting
+point.
+
+*NOTE:* if you plan on using `sleuth` for differential expression, you'll want
+to include the `--bootstrap-samples` argument.
+

--- a/wrappers/kallisto/quant/environment.yaml
+++ b/wrappers/kallisto/quant/environment.yaml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - kallisto

--- a/wrappers/kallisto/quant/wrapper.py
+++ b/wrappers/kallisto/quant/wrapper.py
@@ -1,0 +1,23 @@
+import os
+from snakemake.shell import shell
+
+extra = snakemake.params.get('extra', '')
+log = snakemake.log_fmt_shell()
+
+outdir = [os.path.dirname(i) for i in snakemake.output]
+
+if len(set(outdir)) != 1:
+    raise ValueError("Inconsistent output directories: {0}".format(set(outdir)))
+
+outdir = outdir[0]
+print(os.path.abspath(outdir))
+cmd = (
+    "kallisto quant "
+    "--index {snakemake.input.index} "
+    "--output-dir {outdir} "
+    "--threads {snakemake.threads} "
+    "{extra} "
+    "{snakemake.input.fastq} "
+    "{log} ".format(**locals()))
+print(cmd)
+shell(cmd)

--- a/wrappers/rseqc/geneBody_coverage/environment.yaml
+++ b/wrappers/rseqc/geneBody_coverage/environment.yaml
@@ -4,4 +4,3 @@ channels:
 dependencies:
     - rseqc >=2.6.2
     - r-essentials
-    - icu >=56.1


### PR DESCRIPTION
Adds kallisto index and kallisto quant wrappers.

Kallisto index is also added as a test fixture which is used by kallisto quant.

Also rolled into this are some pep8 edits and a speed-up to the build system. The latter is done by removing the `sudo: required` from `.travis.yaml`, not using sudo in any setup calls, and therefore installing miniconda to $HOME. This lets us use the container-based build system on travis which starts up faster.

This also removes the icu dep from rseqc.