### PR TITLE
use conda

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,6 +1,0 @@
-# pip install snakemake master until there is a new release on bioconda
-git+https://bitbucket.org/snakemake/snakemake.git
-
-# pip install lcdblib until we get it in conda
-git+https://github.com/lcdb/lcdblib.git@master
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,6 @@
-cutadapt == 1.9.1
-fastqc == 0.11.5
-snakemake == 3.8.2
-hisat2 == 2.0.5
-pytest >= 2.9.2
-pandas >= 0.18.1
-seaborn >= 0.7.0
-matplotlib >= 1.5.1
-ipython >=5.1.0
-jsonschema >=2.5.1
-pyyaml >=3.11
-samtools >=1.3
-pysam >=0.9.1
-subread >=1.5.0
-picard >=2.5.0
-r >=3.3.1
-bowtie2 >=2.2.8
-multiqc >=0.8
-gffutils >=0.8.7.1
-pybedtools >=0.7.8
-kallisto >=0.43.0
+# only put tools that are needed for tests (e.g., `bowtie-build` is needed to make sure
+# that bowtie-index worked), not for the wrappers themselves, which should have
+# their own environment.yml files.
+bowtie2
+hisat2
+samtools

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # that bowtie-index worked), not for the wrappers themselves, which should have
 # their own environment.yml files.
 bowtie2
+gffutils
 hisat2
 lcdblib
 pysam

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 bowtie2
 hisat2
 lcdblib
+pysam
 pytest >=2.9.2
 samtools
 snakemake

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # only put tools that are needed for tests (e.g., `bowtie-build` is needed to make sure
 # that bowtie-index worked), not for the wrappers themselves, which should have
 # their own environment.yml files.
-pytest >=2.9.2
-snakemake
 bowtie2
 hisat2
+lcdblib
+pytest >=2.9.2
 samtools
-
+snakemake

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 # only put tools that are needed for tests (e.g., `bowtie-build` is needed to make sure
 # that bowtie-index worked), not for the wrappers themselves, which should have
 # their own environment.yml files.
+pytest >=2.9.2
+snakemake
 bowtie2
 hisat2
 samtools
+

--- a/test/utils.py
+++ b/test/utils.py
@@ -30,7 +30,7 @@ def md5sum(filename):
     return hashlib.md5(data).hexdigest()
 
 
-def run(path, snakefile, check=None, input_data_func=None, tmpdir=None, use_conda=False, **params):
+def run(path, snakefile, check=None, input_data_func=None, tmpdir=None, use_conda=True, **params):
     """
     Parameters
     ----------

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -12,6 +12,7 @@ conda config --add channels conda-forge
 conda config --add channels defaults
 conda config --add channels r
 conda config --add channels bioconda
+conda config --add channels lcdb
 
 conda install -y --file requirements.txt
 pip install -r pip-requirements.txt

--- a/wrappers/bowtie2/align/environment.yaml
+++ b/wrappers/bowtie2/align/environment.yaml
@@ -1,22 +1,7 @@
 channels:
   - bioconda
-  - defaults
-  - conda-forge
+  - lcdb
 dependencies:
   - bowtie2
   - samtools
-# for lcdblib
-  - pytest >=2.9.2
-  - snakemake >=3.8
-  - pandas >=0.18.1
-  - seaborn >=0.7.0
-  - numpy >=1.11.1
-  - matplotlib >=1.5.1
-  - ipython >=5.1.0
-  - jsonschema >=2.5.1
-  - pyyaml >=3.11
-  - pybedtools >=0.7.8
-  - pysam >=0.9.1.4
-  - biopython >=1.6.8
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master
+  - lcdblib

--- a/wrappers/bowtie2/build/environment.yaml
+++ b/wrappers/bowtie2/build/environment.yaml
@@ -1,6 +1,6 @@
 channels:
   - bioconda
+  - lcdb
 dependencies:
   - bowtie2
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master
+  - lcdblib

--- a/wrappers/demo/environment.yaml
+++ b/wrappers/demo/environment.yaml
@@ -1,5 +1,4 @@
 channels:
-  - bioconda
+  - lcdb
 dependencies:
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master
+  - lcdblib

--- a/wrappers/hisat2/align/environment.yaml
+++ b/wrappers/hisat2/align/environment.yaml
@@ -1,7 +1,7 @@
 channels:
   - bioconda
+  - lcdb
 dependencies:
   - hisat2
   - samtools
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master
+  - lcdblib

--- a/wrappers/hisat2/build/environment.yaml
+++ b/wrappers/hisat2/build/environment.yaml
@@ -1,6 +1,6 @@
 channels:
   - bioconda
+  - lcdb
 dependencies:
   - hisat2
-  - pip:
-      - git+https://github.com/lcdb/lcdblib.git@master
+  - lcdblib

--- a/wrappers/kallisto/index/environment.yaml
+++ b/wrappers/kallisto/index/environment.yaml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - kallisto

--- a/wrappers/multiqc/environment.yaml
+++ b/wrappers/multiqc/environment.yaml
@@ -1,4 +1,6 @@
 channels:
   - bioconda
+  - lcdb
 dependencies:
   - multiqc
+  - lcdblib

--- a/wrappers/multiqc/wrapper.py
+++ b/wrappers/multiqc/wrapper.py
@@ -5,19 +5,24 @@ __license__ = "MIT"
 
 import os
 from snakemake.shell import shell
+from lcdblib.utils import utils
+
 outdir = os.path.dirname(snakemake.output[0])
 if not outdir:
     outdir = '.'
 
 extra = snakemake.params.get('extra', "")
 log = snakemake.log_fmt_shell()
-shell(
-    'multiqc '
-    '--quiet '
-    '--outdir {outdir} '
-    '--force '
-    '--filename {snakemake.output} '
-    '{extra} '
-    '{snakemake.params.analysis_directory} '
-    '{log}'
-)
+
+# MultiQC uses Click, which in turn complains if C.UTF-8 is not set
+with utils.temp_env(dict(LC_ALL='C.UTF-8', LC_LANG='C.UTF-8')) as env:
+    shell(
+        'multiqc '
+        '--quiet '
+        '--outdir {outdir} '
+        '--force '
+        '--filename {snakemake.output} '
+        '{extra} '
+        '{snakemake.params.analysis_directory} '
+        '{log}'
+    )


### PR DESCRIPTION
Wrapper environment.yamls have been fixed, and only those requirements using in testing output (not in running the wrappers) are included in `requirements.txt`. `use_conda=True` is now set, so all wrapper tests run in their own environments.

Also, anything that needs it is now pulling lcdblib from the lcdb conda channel rather than pip.

Last, this adds a fix to the MultiQC which temporarily sets environment variables to what's expected by Click (dependency of multiqc).
