### PR TITLE
Explicitly adds `r` channel and `ghostscript`.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ lcdblib
 pysam
 pytest >=2.9.2
 samtools
-snakemake
+snakemake==3.9.1

--- a/wrappers/dupradar/environment.yaml
+++ b/wrappers/dupradar/environment.yaml
@@ -1,6 +1,8 @@
 channels:
   - bioconda
+  - r
   - lcdb
 dependencies:
   - bioconductor-dupradar
   - lcdblib
+  - ghostscript


### PR DESCRIPTION
I was getting errors running test locally until I added the `r` channel
and `ghostscript` as a dependency.