### PR TITLE
Moves tin output to work in TMPDIR.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ install: bash travis-setup.sh
 before_script:
   - export PATH=$HOME/anaconda/bin:$PATH
   - export JAVA_HOME=
+  - export TMPDIR=/tmp
 script: py.test test -v

--- a/wrappers/rseqc/tin/wrapper.py
+++ b/wrappers/rseqc/tin/wrapper.py
@@ -22,13 +22,14 @@ shell(
     '&& cp {snakemake.input.bed} {bed}')
 
 shell(
-    'tin.py '
+    'cd $TMPDIR '
+    '&& tin.py '
     '-i {bam} '
     '-r {bed} '
     '{extra} '
     '{log}')
 
-name = os.path.basename(bam).rstrip('.bam')
+name = bam.rstrip('.bam')
 
 shell(
         'mv {name}.tin.xls {snakemake.output.table} '

--- a/wrappers/rseqc/tin/wrapper.py
+++ b/wrappers/rseqc/tin/wrapper.py
@@ -6,10 +6,13 @@ from snakemake.shell import shell
 
 # All wrappers must be able to handle an optional params.extra.
 extra = snakemake.params.get('extra', '')
-
 # This lets us handle whether to write to a log file or to write to stdout.
 # See snakemake.script.log_fmt_shell for details.
-log = snakemake.log_fmt_shell()
+log = snakemake.log_fmt_shell(stdout=False)
+
+# Get directories that I need to move between
+cwd = os.getcwd()
+tmpdir = os.getenv('TMPDIR')
 
 # tin uses the name of the BAM to create outputs. In order to write outputs to
 # tmp I need to copy the BAM over to tmp.
@@ -21,9 +24,9 @@ shell(
     '&& cp {snakemake.input.bam}.bai {bam}.bai '
     '&& cp {snakemake.input.bed} {bed}')
 
+os.chdir(tmpdir)
 shell(
-    'cd $TMPDIR '
-    '&& tin.py '
+    'tin.py '
     '-i {bam} '
     '-r {bed} '
     '{extra} '
@@ -31,6 +34,7 @@ shell(
 
 name = bam.rstrip('.bam')
 
+os.chdir(cwd)
 shell(
-        'mv {name}.tin.xls {snakemake.output.table} '
-        '&& mv {name}.summary.txt {snakemake.output.summary}')
+    'mv {name}.tin.xls {snakemake.output.table} '
+    '&& mv {name}.summary.txt {snakemake.output.summary}')


### PR DESCRIPTION
tin outputs some tmp files that were not being written to `TMPDIR`, fixes this.