### PR TITLE
Changes moves to copies.

### DIFF
--- a/wrappers/fastq_screen/wrapper.py
+++ b/wrappers/fastq_screen/wrapper.py
@@ -53,7 +53,7 @@ shell(
 )
 
 # Move output to the filenames specified by the rule
-shell("mv {tempdir}/{prefix}_screen.txt {snakemake.output.txt}")
+shell("cp {tempdir}/{prefix}_screen.txt {snakemake.output.txt}")
 
 # Clean up temp
 shell("rm -r {tempdir}")

--- a/wrappers/hisat2/align/wrapper.py
+++ b/wrappers/hisat2/align/wrapper.py
@@ -65,6 +65,7 @@ shell(
     "{samtools_sort_extra} "
     "-O BAM "
     "{bam} "
-    "&& mv {sort_bam} {snakemake.output.bam} "
+    "&& cp {sort_bam} {snakemake.output.bam} "
     "&& rm {bam} "
+    "&& rm {sort_bam} "
 )

--- a/wrappers/rseqc/infer_experiment/wrapper.py
+++ b/wrappers/rseqc/infer_experiment/wrapper.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 from tempfile import NamedTemporaryFile
 from snakemake.shell import shell
 

--- a/wrappers/rseqc/tin/wrapper.py
+++ b/wrappers/rseqc/tin/wrapper.py
@@ -21,6 +21,7 @@ tmpdir = os.getenv('TMPDIR')
 # tmp I need to copy the BAM over to tmp.
 bam = NamedTemporaryFile(suffix='.bam').name
 bed = NamedTemporaryFile(suffix='.bed').name
+name = bam.rstrip('.bam')
 
 shell(
     'cp {snakemake.input.bam} {bam} '
@@ -35,9 +36,16 @@ shell(
     '{extra} '
     '{log}')
 
-name = bam.rstrip('.bam')
+# Cleanup 1
+shell(
+    'rm {bam} '
+    '&& rm {bam}.bai '
+    '&& rm {bed}')
 
+# Move outputs
 os.chdir(cwd)
 shell(
-    'mv {name}.tin.xls {snakemake.output.table} '
-    '&& mv {name}.summary.txt {snakemake.output.summary}')
+    'cp {name}.tin.xls {snakemake.output.table} '
+    '&& cp {name}.summary.txt {snakemake.output.summary} '
+    '&& rm {name}.tin.xls '
+    '&& rm {name}.summary.txt')


### PR DESCRIPTION
When working with temp file I noticed that when moving group permissions
can get messed up. Changed moves to copies to fix this.